### PR TITLE
Add ElevenLabs TTS service

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -36,6 +36,8 @@
     "RequireNeo4j": true,
     "Neo4jBoltPort": 7687,
     "Neo4jHttpPort": 7474,
-    "Neo4jJavaHome": ""
+    "Neo4jJavaHome": "",
+    "ElevenLabsApiKey": "",
+    "ElevenLabsVoiceId": ""
   }
 }

--- a/backend/Controllers/TtsController.cs
+++ b/backend/Controllers/TtsController.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using SwAIvyn.Services;
+
+namespace SwAIvyn.Controllers
+{
+    /// <summary>
+    /// Controller for text-to-speech operations.
+    /// </summary>
+    [ApiController]
+    [Route("api/tts")]
+    public class TtsController : ControllerBase
+    {
+        private readonly ITtsService _ttsService;
+
+        public TtsController(ITtsService ttsService)
+        {
+            _ttsService = ttsService;
+        }
+
+        /// <summary>
+        /// Synthesizes speech audio from text.
+        /// </summary>
+        [HttpPost("synthesize")]
+        public async Task<IActionResult> Synthesize([FromBody] TtsRequest request)
+        {
+            var audio = await _ttsService.SynthesizeAsync(request.Text, request.VoiceId);
+            return File(audio, "audio/mpeg");
+        }
+    }
+
+    /// <summary>
+    /// Request model for TTS synthesis.
+    /// </summary>
+    public class TtsRequest
+    {
+        /// <summary>The text to synthesize.</summary>
+        public string Text { get; set; } = string.Empty;
+        /// <summary>Optional voice ID to use.</summary>
+        public string? VoiceId { get; set; }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -308,6 +308,7 @@ builder.Services.AddScoped<IBrainService, BrainService>();
 
 // Register HybridSearchService for calling search.py API
 builder.Services.AddHttpClient<IHybridSearchService, HybridSearchService>();
+builder.Services.AddHttpClient<ITtsService, ElevenLabsTtsService>();
 
 // Add Neo4j and BrainGraph services
 builder.Services.AddScoped<INeo4jService, Neo4jService>();

--- a/backend/Services/ElevenLabsTtsService.cs
+++ b/backend/Services/ElevenLabsTtsService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace SwAIvyn.Services
+{
+    /// <summary>
+    /// ElevenLabs text-to-speech service implementation.
+    /// </summary>
+    public class ElevenLabsTtsService : ITtsService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ISettingsProvider _settingsProvider;
+        private readonly ISimpleLoggerService _logger;
+
+        public ElevenLabsTtsService(
+            HttpClient httpClient,
+            ISettingsProvider settingsProvider,
+            ISimpleLoggerService logger)
+        {
+            _httpClient = httpClient;
+            _settingsProvider = settingsProvider;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public async Task<byte[]> SynthesizeAsync(string text, string? voiceId = null)
+        {
+            try
+            {
+                var apiKey = _settingsProvider.GetElevenLabsApiKey();
+                voiceId ??= _settingsProvider.GetElevenLabsVoiceId();
+
+                if (string.IsNullOrWhiteSpace(apiKey) || string.IsNullOrWhiteSpace(voiceId))
+                {
+                    throw new InvalidOperationException("ElevenLabs API key or voice ID not configured.");
+                }
+
+                var url = $"https://api.elevenlabs.io/v1/text-to-speech/{voiceId}";
+                var requestJson = JsonSerializer.Serialize(new { text });
+                using var request = new HttpRequestMessage(HttpMethod.Post, url);
+                request.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+                request.Headers.Add("xi-api-key", apiKey);
+
+                _logger.LogInfo($"[TTS REQUEST] POST {url} (text length {text.Length})");
+                var response = await _httpClient.SendAsync(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var err = await response.Content.ReadAsStringAsync();
+                    _logger.LogError($"ElevenLabs TTS failed: {(int)response.StatusCode} {response.StatusCode} - {err}");
+                    throw new Exception($"ElevenLabs API error: {response.StatusCode}");
+                }
+
+                _logger.LogInfo("[TTS RESPONSE] Success");
+                return await response.Content.ReadAsByteArrayAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Failed to synthesize speech", ex);
+                throw;
+            }
+        }
+    }
+}

--- a/backend/Services/ITtsService.cs
+++ b/backend/Services/ITtsService.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace SwAIvyn.Services
+{
+    /// <summary>
+    /// Interface for text-to-speech services.
+    /// </summary>
+    public interface ITtsService
+    {
+        /// <summary>
+        /// Synthesizes speech audio from text.
+        /// </summary>
+        /// <param name="text">The text to synthesize.</param>
+        /// <param name="voiceId">Optional voice ID.</param>
+        /// <returns>Audio data bytes.</returns>
+        Task<byte[]> SynthesizeAsync(string text, string? voiceId = null);
+    }
+}

--- a/backend/Services/SettingsProvider.cs
+++ b/backend/Services/SettingsProvider.cs
@@ -47,6 +47,18 @@ namespace SwAIvyn.Services
         /// </summary>
         /// <returns>Neo4j HTTP port</returns>
         int GetNeo4jHttpPort();
+
+        /// <summary>
+        /// Gets the ElevenLabs API key from configuration
+        /// </summary>
+        /// <returns>API key string</returns>
+        string GetElevenLabsApiKey();
+
+        /// <summary>
+        /// Gets the default ElevenLabs voice ID from configuration
+        /// </summary>
+        /// <returns>Voice ID string</returns>
+        string GetElevenLabsVoiceId();
     }
 
     /// <summary>
@@ -63,6 +75,8 @@ namespace SwAIvyn.Services
         private const string NEO4J_URI_KEY = "Neo4jUri";
         private const string NEO4J_BOLT_PORT_KEY = "Neo4jBoltPort";
         private const string NEO4J_HTTP_PORT_KEY = "Neo4jHttpPort";
+        private const string ELEVENLABS_API_KEY = "ElevenLabsApiKey";
+        private const string ELEVENLABS_VOICE_ID = "ElevenLabsVoiceId";
 
         /// <summary>
         /// Initializes a new instance of the SettingsProvider
@@ -123,6 +137,18 @@ namespace SwAIvyn.Services
         {
             var portStr = GetSetting(NEO4J_HTTP_PORT_KEY, "7474");
             return int.TryParse(portStr, out int port) ? port : 7474;
+        }
+
+        /// <inheritdoc/>
+        public string GetElevenLabsApiKey()
+        {
+            return GetSetting(ELEVENLABS_API_KEY, string.Empty);
+        }
+
+        /// <inheritdoc/>
+        public string GetElevenLabsVoiceId()
+        {
+            return GetSetting(ELEVENLABS_VOICE_ID, string.Empty);
         }
     }
 }

--- a/backend/Services/SettingsService.cs
+++ b/backend/Services/SettingsService.cs
@@ -90,6 +90,20 @@ namespace SwAIvyn.Services
         Task<int> GetNeo4jHttpPortAsync(Guid? userId);
 
         /// <summary>
+        /// Gets the ElevenLabs API key from settings or configuration
+        /// </summary>
+        /// <param name="userId">User ID (null for global settings)</param>
+        /// <returns>API key string</returns>
+        Task<string> GetElevenLabsApiKeyAsync(Guid? userId);
+
+        /// <summary>
+        /// Gets the default ElevenLabs voice ID from settings or configuration
+        /// </summary>
+        /// <param name="userId">User ID (null for global settings)</param>
+        /// <returns>Voice ID string</returns>
+        Task<string> GetElevenLabsVoiceIdAsync(Guid? userId);
+
+        /// <summary>
         /// Initializes default settings for a user
         /// </summary>
         /// <param name="userId">User ID</param>
@@ -126,6 +140,8 @@ namespace SwAIvyn.Services
         private const string NEO4J_URI_KEY = "Neo4jUri";
         private const string NEO4J_BOLT_PORT_KEY = "Neo4jBoltPort";
         private const string NEO4J_HTTP_PORT_KEY = "Neo4jHttpPort";
+        private const string ELEVENLABS_API_KEY = "ElevenLabsApiKey";
+        private const string ELEVENLABS_VOICE_ID = "ElevenLabsVoiceId";
 
         /// <summary>
         /// Initializes a new instance of the SettingsService
@@ -307,6 +323,18 @@ namespace SwAIvyn.Services
         }
 
         /// <inheritdoc/>
+        public async Task<string> GetElevenLabsApiKeyAsync(Guid? userId)
+        {
+            return await GetSettingAsync(userId, ELEVENLABS_API_KEY, string.Empty);
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GetElevenLabsVoiceIdAsync(Guid? userId)
+        {
+            return await GetSettingAsync(userId, ELEVENLABS_VOICE_ID, string.Empty);
+        }
+
+        /// <inheritdoc/>
         public async Task<bool> InitializeDefaultSettingsAsync(Guid userId)
         {
             try
@@ -322,6 +350,8 @@ namespace SwAIvyn.Services
                     { NEO4J_URI_KEY, "http://localhost:7474" },
                     { NEO4J_BOLT_PORT_KEY, "7687" },
                     { NEO4J_HTTP_PORT_KEY, "7474" },
+                    { ELEVENLABS_API_KEY, "" },
+                    { ELEVENLABS_VOICE_ID, "" },
                     { "EnableStreaming", "true" },
                     { "Theme", "dark" },
                     { "Language", "en" },

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -36,6 +36,8 @@
     "RequireNeo4j": true,
     "Neo4jBoltPort": 7687,
     "Neo4jHttpPort": 7474,
-    "Neo4jJavaHome": ""
+    "Neo4jJavaHome": "",
+    "ElevenLabsApiKey": "",
+    "ElevenLabsVoiceId": ""
   }
 }

--- a/frontend/src/components/voice-room/MiniChat.tsx
+++ b/frontend/src/components/voice-room/MiniChat.tsx
@@ -21,6 +21,24 @@ const MiniChat = ({ isOpen, onClose }: MiniChatProps) => {
   const [messages, setMessages] = useState<Message[]>(initialMessages);
   const [inputText, setInputText] = useState('');
 
+  const playTts = async (text: string) => {
+    try {
+      const resp = await fetch('/api/tts/synthesize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      });
+      if (resp.ok) {
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        audio.play();
+      }
+    } catch (err) {
+      console.error('TTS failed', err);
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!inputText.trim()) return;
@@ -44,6 +62,7 @@ const MiniChat = ({ isOpen, onClose }: MiniChatProps) => {
         timestamp: new Date().toISOString()
       };
       setMessages(prev => [...prev, aiMessage]);
+      playTts(aiMessage.text);
     }, 1000);
   };
   

--- a/frontend/src/pages/VoiceRoomPage.tsx
+++ b/frontend/src/pages/VoiceRoomPage.tsx
@@ -7,6 +7,24 @@ import MiniChat from '../components/voice-room/MiniChat';
 const VoiceRoomPage = () => {
   const [isMiniChatOpen, setIsMiniChatOpen] = useState(false);
   const [isListening, setIsListening] = useState(false);
+
+  const playTts = async (text: string) => {
+    try {
+      const resp = await fetch('/api/tts/synthesize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      });
+      if (resp.ok) {
+        const blob = await resp.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio(url);
+        audio.play();
+      }
+    } catch (err) {
+      console.error('TTS failed', err);
+    }
+  };
   
   const toggleListening = () => {
     setIsListening(!isListening);
@@ -50,6 +68,7 @@ const VoiceRoomPage = () => {
               
               <button
                 className="p-4 rounded-full shadow-md bg-white text-gray-700 hover:bg-gray-50 flex items-center justify-center transition-all"
+                onClick={() => playTts('Hello, how can I assist you today?')}
               >
                 <Volume2 size={24} />
               </button>


### PR DESCRIPTION
## Summary
- implement ITtsService and ElevenLabsTtsService
- expose POST /api/tts/synthesize endpoint
- store ElevenLabs API settings
- call new TTS endpoint from voice components

## Testing
- `npm install --ignore-scripts`
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684007c7b2d08329a92413c01836a7ed