### PR TITLE
Add LM Studio model list endpoint

### DIFF
--- a/backend/Controllers/LlmController.cs
+++ b/backend/Controllers/LlmController.cs
@@ -99,6 +99,24 @@ namespace SwAIvyn.Controllers
         }
 
         /// <summary>
+        /// Gets the list of models available in LM Studio.
+        /// </summary>
+        [HttpGet("lmstudio/models")]
+        public async Task<IActionResult> GetLmStudioModels([FromQuery] Guid? userId = null)
+        {
+            try
+            {
+                var models = await _llmConnectorService.GetLmStudioModelsAsync(userId);
+                return Ok(models);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error getting LM Studio models", ex);
+                return StatusCode(500, "An error occurred while getting LM Studio models");
+            }
+        }
+
+        /// <summary>
         /// Tests connection to LM Studio by fetching the current model.
         /// </summary>
         [HttpGet("lmstudio/test")]

--- a/backend/Services/LlmConnectorService.cs
+++ b/backend/Services/LlmConnectorService.cs
@@ -25,6 +25,11 @@ namespace SwAIvyn.Services
         Task<string> GetLmStudioModelAsync(Guid? userId = null);
 
         /// <summary>
+        /// Lists the models available from LM Studio.
+        /// </summary>
+        Task<IEnumerable<string>> GetLmStudioModelsAsync(Guid? userId = null);
+
+        /// <summary>
         /// Lists available OpenAI models.
         /// </summary>
         Task<IEnumerable<string>> GetOpenAiModelsAsync(Guid? userId = null);
@@ -159,6 +164,49 @@ namespace SwAIvyn.Services
             {
                 _logger.LogError($"Failed to get LM Studio model: {ex.Message}");
                 return string.Empty;
+            }
+        }
+
+        public async Task<IEnumerable<string>> GetLmStudioModelsAsync(Guid? userId = null)
+        {
+            try
+            {
+                var lmStudioApiUrl = (await _configurationService.GetLmStudioApiUrl()).TrimEnd('/');
+                _logger.LogInfo($"Using LM Studio API URL: {lmStudioApiUrl}");
+
+                var results = new List<string>();
+
+                // Try OpenAI-compatible endpoint first
+                var openAiResponse = await _httpClient.GetAsync($"{lmStudioApiUrl}/v1/models");
+                if (openAiResponse.IsSuccessStatusCode)
+                {
+                    var openAiModels = await openAiResponse.Content.ReadFromJsonAsync<OpenAiModelsResponse>();
+                    if (openAiModels?.Data != null && openAiModels.Data.Count > 0)
+                    {
+                        results.AddRange(openAiModels.Data.Select(m => m.Id));
+                    }
+                }
+
+                // If no models found, fallback to legacy /models endpoint
+                if (results.Count == 0)
+                {
+                    var legacyResponse = await _httpClient.GetAsync($"{lmStudioApiUrl}/models");
+                    if (legacyResponse.IsSuccessStatusCode)
+                    {
+                        var legacyData = await legacyResponse.Content.ReadFromJsonAsync<LmStudioModelsResponse>();
+                        if (legacyData?.Data != null && legacyData.Data.Count > 0)
+                        {
+                            results.AddRange(legacyData.Data.Select(m => m.Name));
+                        }
+                    }
+                }
+
+                return results;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to get LM Studio models: {ex.Message}");
+                return new List<string>();
             }
         }
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -361,9 +361,9 @@ const ModelSettings = () => {
         } else if (selectedEngine === 'lmstudio') {
           const res = await fetch('/api/llm/lmstudio/models');
           if (res.ok) {
-            const data = await res.json();
-            if (data.data?.length > 0) {
-              setSelectedModel(data.data[0].id);
+            const list = await res.json();
+            if (list.length > 0) {
+              setSelectedModel(list[0]);
             }
           }
         } else if (selectedEngine === 'openai') {
@@ -400,8 +400,8 @@ const ModelSettings = () => {
       if (engineToSet === 'lmstudio') {
         const res = await fetch('/api/llm/lmstudio/models');
         if (res.ok) {
-          const data = await res.json();
-          if (data.data?.length > 0) modelToSet = data.data[0].id;
+          const list = await res.json();
+          if (list.length > 0) modelToSet = list[0];
         }
       } else if (engineToSet === 'ollama') {
         const res = await fetch('/api/llm/ollama/models');


### PR DESCRIPTION
## Summary
- add new `lmstudio/models` route in LlmController
- implement `GetLmStudioModelsAsync` in LlmConnectorService
- adjust SettingsPage to consume model list format

## Testing
- `npm install`
- `npm run lint` *(fails: 34 errors, 10 warnings)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684149ff474483299a0ebff51ba0109c