### PR TITLE
I've made some progress on the LLM dropdowns and started implementing…

### DIFF
--- a/backend/Controllers/ModulesController.cs
+++ b/backend/Controllers/ModulesController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using SwAIvyn.Services;
+using System;
+using System.Threading.Tasks;
+
+namespace SwAIvyn.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ModulesController : ControllerBase
+    {
+        private readonly IModuleService _moduleService;
+        private readonly ISimpleLoggerService _logger;
+
+        public ModulesController(IModuleService moduleService, ISimpleLoggerService logger)
+        {
+            _moduleService = moduleService;
+            _logger = logger;
+        }
+
+        [HttpGet("user/{userId}")]
+        public async Task<IActionResult> GetModulesForUser(Guid? userId)
+        {
+            try
+            {
+                if (userId == null)
+                {
+                    // Use the default/only user ID if none provided or handle as appropriate
+                    // For this app, it seems '00000000-0000-0000-0000-000000000001' is used as a default
+                    // However, the frontend sends the actual user ID.
+                    // Let's assume a userId must be provided for now, or fall back to a default if that's the design.
+                    // For now, let's proceed with the userId passed.
+                }
+                _logger.LogInfo($"Fetching modules for user: {userId}");
+                var modules = await _moduleService.GetModulesAsync(userId);
+                return Ok(modules);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting modules for user {userId}: {ex.Message}", ex);
+                return StatusCode(500, $"An error occurred while getting modules: {ex.Message}");
+            }
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -344,6 +344,9 @@ builder.Services.AddHttpClient<ITtsService, ElevenLabsTtsService>();
 // Add agent service
 builder.Services.AddScoped<IAgentService, AgentService>();
 
+// Add module service
+builder.Services.AddSingleton<IModuleService, ModuleService>();
+
 builder.Services.AddSignalR().AddJsonProtocol();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/backend/Services/IModuleService.cs
+++ b/backend/Services/IModuleService.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SwAIvyn.Services
+{
+    public interface IModuleService
+    {
+        Task<IEnumerable<ModuleDefinition>> GetModulesAsync(Guid? userId);
+    }
+
+    public class ModuleDefinition // Corresponds to frontend's Module interface
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public string Description { get; set; }
+        public string Category { get; set; }
+        public bool Enabled { get; set; }
+        public bool Installed { get; set; }
+        // Add any other fields that might come from the mcpServers config if needed for display
+    }
+}

--- a/backend/Services/ModuleService.cs
+++ b/backend/Services/ModuleService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting; // Required for IHostEnvironment
+
+namespace SwAIvyn.Services
+{
+    public class ModuleService : IModuleService
+    {
+        private readonly ISimpleLoggerService _logger;
+        private readonly string _mcpConfigPath;
+        private McpConfig _mcpConfig;
+
+        // Define structure for mcpServers.json
+        public class McpConfig
+        {
+            public Dictionary<string, McpServerDetail> McpServers { get; set; } = new Dictionary<string, McpServerDetail>();
+        }
+
+        public class McpServerDetail
+        {
+            public List<string> AutoApprove { get; set; } = new List<string>();
+            public bool Disabled { get; set; } // Maps to !Enabled
+            public int Timeout { get; set; }
+            public string Command { get; set; }
+            public List<string> Args { get; set; } = new List<string>();
+            public Dictionary<string, string> Env { get; set; } = new Dictionary<string, string>();
+            public string TransportType { get; set; }
+            // Add other potential fields like 'description', 'version', 'category' if they exist in the real config
+            // For now, we'll derive some of these.
+        }
+
+        public ModuleService(ISimpleLoggerService logger, IHostEnvironment hostEnvironment)
+        {
+            _logger = logger;
+            _mcpConfigPath = Path.Combine(hostEnvironment.ContentRootPath, "mcpServers.json");
+            LoadMcpConfig().ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        private async Task LoadMcpConfig()
+        {
+            try
+            {
+                if (File.Exists(_mcpConfigPath))
+                {
+                    _logger.LogInfo($"Loading MCP configuration from: {_mcpConfigPath}");
+                    var json = await File.ReadAllTextAsync(_mcpConfigPath);
+                    _mcpConfig = JsonSerializer.Deserialize<McpConfig>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    _logger.LogInfo($"Successfully loaded {_mcpConfig?.McpServers?.Count ?? 0} MCP servers.");
+                }
+                else
+                {
+                    _logger.LogWarning($"MCP configuration file not found at: {_mcpConfigPath}. Creating a default/empty config.");
+                    _mcpConfig = GetDefaultMcpConfig();
+                    // Optionally, write the default config to the file path
+                    // var defaultJson = JsonSerializer.Serialize(_mcpConfig, new JsonSerializerOptions { WriteIndented = true });
+                    // await File.WriteAllTextAsync(_mcpConfigPath, defaultJson);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error loading MCP configuration: {ex.Message}", ex);
+                _mcpConfig = GetDefaultMcpConfig(); // Fallback to default
+            }
+        }
+
+        private McpConfig GetDefaultMcpConfig()
+        {
+            // Provides the example structure if mcpServers.json is missing or fails to load
+            return new McpConfig
+            {
+                McpServers = new Dictionary<string, McpServerDetail>
+                {
+                    {
+                        "github.com/Flux159/mcp-server-kubernetes", new McpServerDetail
+                        {
+                            Disabled = true, // Example: This one is installed but disabled
+                            // Other fields from your example...
+                        }
+                    },
+                    {
+                        "github.com/github/github-mcp-server", new McpServerDetail
+                        {
+                            Disabled = false, // Example: Installed and enabled
+                            // Other fields...
+                        }
+                    }
+                    // Add more default examples if necessary
+                }
+            };
+        }
+
+        public async Task<IEnumerable<ModuleDefinition>> GetModulesAsync(Guid? userId)
+        {
+            // For now, userId is not used, but it's in the interface for future-proofing.
+            // If config hasn't loaded somehow, try again (or ensure constructor handles it)
+            if (_mcpConfig == null || _mcpConfig.McpServers == null)
+            {
+                _logger.LogWarning("McpConfig or McpServers is null in GetModulesAsync. Attempting reload or using default.");
+                await LoadMcpConfig(); // Ensure it's loaded
+                    if (_mcpConfig == null || _mcpConfig.McpServers == null) // Still null after attempt
+                    {
+                    _logger.LogError("Failed to load McpConfig even after explicit call in GetModulesAsync. Returning empty list.");
+                    return new List<ModuleDefinition>();
+                    }
+            }
+
+            var modules = _mcpConfig.McpServers.Select(kvp =>
+            {
+                var serverId = kvp.Key;
+                var serverDetails = kvp.Value;
+                var nameParts = serverId.Split('/');
+                var name = nameParts.Length > 1 ? nameParts.Last() : serverId; // Simple name extraction
+
+                return new ModuleDefinition
+                {
+                    Id = serverId,
+                    Name = name,
+                    Version = "1.0.0", // Placeholder, ideally from config or git
+                    Description = $"Module for {name}", // Placeholder
+                    Category = GetCategoryFromName(name), // Simple categorization
+                    Enabled = !serverDetails.Disabled,
+                    Installed = true // All modules in mcpServers.json are considered "installed"
+                };
+            }).ToList();
+
+            _logger.LogInfo($"Returning {modules.Count} modules for user {userId?.ToString() ?? "Global"}.");
+            return modules;
+        }
+
+        private string GetCategoryFromName(string name)
+        {
+            if (name.ToLower().Contains("kubernetes")) return "Cloud & Infrastructure";
+            if (name.ToLower().Contains("github")) return "Developer Tools";
+            if (name.ToLower().Contains("filesystem")) return "System Utilities";
+            if (name.ToLower().Contains("sequentialthinking")) return "AI & Machine Learning";
+            if (name.ToLower().Contains("git")) return "Developer Tools";
+            if (name.ToLower().Contains("blender")) return "Graphics & Design";
+            if (name.ToLower().Contains("unity")) return "Game Development";
+            if (name.ToLower().Contains("sqlite") || name.ToLower().Contains("neo4j")) return "Databases";
+            if (name.ToLower().Contains("memory")) return "AI & Machine Learning";
+            if (name.ToLower().Contains("notion")) return "Productivity";
+            if (name.ToLower().Contains("browser-tools")) return "Web Development";
+            return "Extensions"; // Default category
+        }
+    }
+}

--- a/backend/SwAIvyn.csproj
+++ b/backend/SwAIvyn.csproj
@@ -51,6 +51,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="mcpServers.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- Post-build event to copy executable to root directory -->
   <Target Name="CopyToRoot" AfterTargets="Build">
     <ItemGroup>

--- a/backend/mcpServers.json
+++ b/backend/mcpServers.json
@@ -1,0 +1,149 @@
+{
+    "mcpServers": {
+        "github.com/Flux159/mcp-server-kubernetes": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 300,
+            "command": "mcp-server-kubernetes",
+            "args": [
+                "--debug"
+            ],
+            "env": {
+                "KUBECONFIG": "~/.kube/config"
+            },
+            "transportType": "stdio"
+        },
+        "github.com/github/github-mcp-server": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-github",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-filesystem": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-filesystem",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-sequentialthinking": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-sequentialthinking",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-git": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": true,
+            "timeout": 120,
+            "command": "mcp-server-git",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-blender": {
+            "autoApprove": [],
+            "disabled": true,
+            "timeout": 300,
+            "command": "mcp-server-blender",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-unity": {
+            "autoApprove": [],
+            "disabled": true,
+            "timeout": 300,
+            "command": "mcp-server-unity",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-sqlite": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-sqlite",
+            "args": [
+                "--db-path",
+                "data/mcp_sqlite.db"
+            ],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-memory": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-memory",
+            "args": [
+                "--db-path",
+                "data/mcp_memory.db"
+            ],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-notion": {
+            "autoApprove": [],
+            "disabled": true,
+            "timeout": 120,
+            "command": "mcp-server-notion",
+            "args": [],
+            "env": {
+                "NOTION_API_KEY": "your_notion_api_key_here"
+            },
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-neo4j": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": true,
+            "timeout": 180,
+            "command": "mcp-server-neo4j",
+            "args": [
+                "--uri",
+                "bolt://localhost:7687",
+                "--username",
+                "neo4j",
+                "--password",
+                "your_neo4j_password"
+            ],
+            "env": {},
+            "transportType": "stdio"
+        },
+        "github.com/SwAIvyn/mcp-server-browser-tools": {
+            "autoApprove": [
+                "*"
+            ],
+            "disabled": false,
+            "timeout": 120,
+            "command": "mcp-server-browser-tools",
+            "args": [],
+            "env": {},
+            "transportType": "stdio"
+        }
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ChatPage from './pages/ChatPage';
 import VoiceRoomPage from './pages/VoiceRoomPage';
 import MemoryPage from './pages/MemoryPage';
 import ModulesPage from './pages/ModulesPage';
+import ModuleStorePage from './pages/ModuleStorePage';
 import AgentsTab from './components/AgentsTab'; // Changed this line
 import UserProfilePage from './pages/UserProfilePage';
 import SettingsPage from './pages/SettingsPage';
@@ -45,6 +46,7 @@ function AppContent() {
           <Route path="voice-room" element={<VoiceRoomPage />} />
           <Route path="memory" element={<MemoryPage />} />
           <Route path="modules" element={<ModulesPage />} />
+          <Route path="module-store" element={<ModuleStorePage />} />
           <Route path="agents" element={<AgentsTab />} /> {/* Changed this line */}
           <Route path="profile" element={<UserProfilePage />} />
           <Route path="settings" element={<SettingsPage />} />

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -168,13 +168,13 @@ const ChatPage = () => {
   useEffect(() => {
     const llms = [{ value: 'default', label: 'Default LLM', engine: null, model: null }];
 
-    if (ollamaModelsApi && Array.isArray(ollamaModelsApi)) {
+    if (ollamaModelsApi && Array.isArray(ollamaModelsApi) && ollamaModelsApi.length > 0) {
       ollamaModelsApi.forEach((model: string) => llms.push({ value: `ollama:${model}`, label: `Ollama: ${model}`, engine: 'ollama', model: model }));
     } else {
       llms.push({ value: `ollama:default`, label: `Ollama (Default Model)`, engine: 'ollama', model: null});
     }
 
-    if (lmStudioModelsApi?.data && Array.isArray(lmStudioModelsApi.data)) {
+    if (lmStudioModelsApi?.data && Array.isArray(lmStudioModelsApi.data) && lmStudioModelsApi.data.length > 0) {
       lmStudioModelsApi.data.forEach((model: any) => llms.push({ value: `lmstudio:${model.id}`, label: `LM Studio: ${model.id}`, engine: 'lmstudio', model: model.id }));
     } else if (lmStudioModelsApi?.data?.id) {
        llms.push({ value: `lmstudio:${lmStudioModelsApi.data.id}`, label: `LM Studio: ${lmStudioModelsApi.data.id}`, engine: 'lmstudio', model: lmStudioModelsApi.data.id});
@@ -182,13 +182,13 @@ const ChatPage = () => {
        llms.push({ value: `lmstudio:default`, label: `LM Studio (Loaded Model)`, engine: 'lmstudio', model: null });
     }
 
-    if (openAiModelsApi && Array.isArray(openAiModelsApi)) {
+    if (openAiModelsApi && Array.isArray(openAiModelsApi) && openAiModelsApi.length > 0) {
       openAiModelsApi.forEach((model: string) => llms.push({ value: `openai:${model}`, label: `OpenAI: ${model}`, engine: 'openai', model: model }));
     } else {
        llms.push({ value: `openai:default`, label: `OpenAI (Default)`, engine: 'openai', model: null });
     }
 
-    if (claudeModelsApi && Array.isArray(claudeModelsApi)) {
+    if (claudeModelsApi && Array.isArray(claudeModelsApi) && claudeModelsApi.length > 0) {
       claudeModelsApi.forEach((model: string) => llms.push({ value: `claude:${model}`, label: `Claude: ${model}`, engine: 'claude', model: model }));
     } else {
       llms.push({ value: `claude:default`, label: `Claude (Default)`, engine: 'claude', model: null });

--- a/frontend/src/pages/ModuleStorePage.tsx
+++ b/frontend/src/pages/ModuleStorePage.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { ArrowLeft } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const ModuleStorePage: React.FC = () => {
+  return (
+    <motion.div
+      className="min-h-[calc(100vh-64px)] bg-gray-50 p-4"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <div className="max-w-5xl mx-auto">
+        <div className="mb-6">
+          <Link to="/modules" className="flex items-center text-primary-500 hover:text-primary-700 transition-colors">
+            <ArrowLeft size={20} className="mr-2" />
+            Back to Modules
+          </Link>
+        </div>
+        <h1 className="text-2xl font-medium text-gray-800 mb-4">Module Store</h1>
+        <div className="bg-white p-6 rounded-lg shadow-soft">
+          <p className="text-gray-700">
+            Welcome to the Module Store! This is where you will be able to browse and install new MCP modules to extend the capabilities of your AI assistant.
+          </p>
+          <p className="text-gray-700 mt-2">
+            This section is currently under development.
+          </p>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+export default ModuleStorePage;

--- a/frontend/src/pages/ModulesPage.tsx
+++ b/frontend/src/pages/ModulesPage.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Download, Settings, RefreshCw, X, Search, Plus, Package } from 'lucide-react';
 import InlineSpinner from '../components/ui/InlineSpinner';
 
@@ -17,6 +18,7 @@ const ModulesPage = () => {
   const [modules, setModules] = useState<Module[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     loadModules();
@@ -108,7 +110,7 @@ const ModulesPage = () => {
                   ? 'Try adjusting your search criteria.'
                   : 'No modules are currently installed. Browse the module store to add functionality to your AI assistant.'}
               </p>
-              <button className="btn btn-primary">
+              <button className="btn btn-primary" onClick={() => navigate('/module-store')}>
                 <Plus size={16} className="mr-1.5" />
                 Browse Module Store
               </button>


### PR DESCRIPTION
… the initial MCP module functionality.

Here's a summary of the changes:

1.  **LLM Dropdown Fixes:**
    *   I modified `frontend/src/pages/ChatPage.tsx` to ensure that dropdown menus for ChatGPT (OpenAI) and ClaudeAI correctly display a "Default" model option if the backend returns an empty list of specific models. This prevents the issue where no models would appear for these providers. I also applied this fix to Ollama and LMStudio for consistency.

2.  **MCP Module Functionality (Phase 1):**
    *   **Frontend:**
        *   The "Browse Module Store" button on `frontend/src/pages/ModulesPage.tsx` now navigates to a new placeholder route `/module-store`.
        *   I created `frontend/src/pages/ModuleStorePage.tsx` as a placeholder for the module store.
        *   I updated `frontend/src/App.tsx` to include the new route.
    *   **Backend:**
        *   I created `ModulesController.cs` with a `GET /api/modules/user/{userId}` endpoint.
        *   I created `ModuleService.cs` and `IModuleService.cs`. The service loads module configurations from a new `backend/mcpServers.json` file (using the structure you provided in the issue). If the file is missing, it uses a default configuration.
        *   The service transforms the loaded MCP server details into `ModuleDefinition` objects suitable for the frontend.
        *   I registered `ModuleService` for dependency injection.
        *   I added `mcpServers.json` to the backend project and ensured it's copied to the output directory.

The "Add Module" button on the Modules page remains non-functional for now, and I plan to tackle the advanced MCP module installation (Git cloning, Docker integration) in the future.