### PR TITLE
Fix: Isolate memories by user and sync chat configurations

### DIFF
--- a/backend/Controllers/ChatController.cs
+++ b/backend/Controllers/ChatController.cs
@@ -1,8 +1,34 @@
 using Microsoft.AspNetCore.Mvc;
+using SwAIvyn.Services;
+using System;
 using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
 
 namespace SwAIvyn.Controllers
 {
+    // --- Data Transfer Objects (DTOs) for Chat Settings ---
+
+    public class ChatSettingsDto
+    {
+        public string LlmEngine { get; set; }
+        public string LlmModel { get; set; }
+        public string TtsProvider { get; set; }
+        public string TtsVoiceId { get; set; }
+    }
+
+    public class UpdateChatSettingsRequest
+    {
+        [Required]
+        public string LlmEngine { get; set; }
+
+        [Required]
+        public string LlmModel { get; set; }
+
+        public string TtsProvider { get; set; }
+
+        public string TtsVoiceId { get; set; }
+    }
+
     /// <summary>
     /// Controller for chat-related API endpoints.
     /// </summary>
@@ -10,6 +36,88 @@ namespace SwAIvyn.Controllers
     [Route("api/[controller]")]
     public class ChatController : ControllerBase
     {
+        private readonly ISettingsService _settingsService;
+        private readonly ISimpleLoggerService _logger; // Optional: for logging
+
+        // Constants for settings keys
+        private const string ChatLlmEngineKey = "Chat.LlmEngine";
+        private const string ChatLlmModelKey = "Chat.LlmModel";
+        private const string ChatTtsProviderKey = "Chat.TtsProvider";
+        private const string ChatTtsVoiceIdKey = "Chat.TtsVoiceId";
+
+        public ChatController(ISettingsService settingsService, ISimpleLoggerService logger)
+        {
+            _settingsService = settingsService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieves the chat configurations for a specific user.
+        /// </summary>
+        /// <param name="userId">The ID of the user.</param>
+        /// <returns>The chat configurations.</returns>
+        [HttpGet("settings/{userId}")]
+        public async Task<IActionResult> GetChatSettings(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                return BadRequest("Valid userId is required.");
+            }
+
+            try
+            {
+                var settingsDto = new ChatSettingsDto
+                {
+                    LlmEngine = await _settingsService.GetSettingAsync(userId, ChatLlmEngineKey, "ollama"), // Default to "ollama"
+                    LlmModel = await _settingsService.GetSettingAsync(userId, ChatLlmModelKey, string.Empty),
+                    TtsProvider = await _settingsService.GetSettingAsync(userId, ChatTtsProviderKey, "elevenlabs"), // Default to "elevenlabs"
+                    TtsVoiceId = await _settingsService.GetSettingAsync(userId, ChatTtsVoiceIdKey, string.Empty)
+                };
+                return Ok(settingsDto);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Error getting chat settings for user {userId}: {ex.Message}", ex);
+                return StatusCode(500, "An error occurred while retrieving chat settings.");
+            }
+        }
+
+        /// <summary>
+        /// Updates the chat configurations for a specific user.
+        /// </summary>
+        /// <param name="userId">The ID of the user.</param>
+        /// <param name="request">The chat configuration settings.</param>
+        /// <returns>A success message or error.</returns>
+        [HttpPut("settings/{userId}")]
+        public async Task<IActionResult> UpdateChatSettings(Guid userId, [FromBody] UpdateChatSettingsRequest request)
+        {
+            if (userId == Guid.Empty)
+            {
+                return BadRequest("Valid userId is required.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                await _settingsService.SetSettingAsync(userId, ChatLlmEngineKey, request.LlmEngine);
+                await _settingsService.SetSettingAsync(userId, ChatLlmModelKey, request.LlmModel);
+                await _settingsService.SetSettingAsync(userId, ChatTtsProviderKey, request.TtsProvider ?? string.Empty);
+                await _settingsService.SetSettingAsync(userId, ChatTtsVoiceIdKey, request.TtsVoiceId ?? string.Empty);
+
+                _logger?.LogInfo($"Chat settings updated for user {userId}. Engine: {request.LlmEngine}, Model: {request.LlmModel}");
+                return Ok(new { message = "Chat settings updated successfully." });
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError($"Error updating chat settings for user {userId}: {ex.Message}", ex);
+                return StatusCode(500, "An error occurred while updating chat settings.");
+            }
+        }
+
         /// <summary>
         /// Retrieves the chat history for the user.
         /// </summary>
@@ -30,6 +138,7 @@ namespace SwAIvyn.Controllers
         public async Task<IActionResult> SendMessage([FromBody] object message)
         {
             // Placeholder for sending a message
+            // Consider using chat settings (LLM engine/model) retrieved for the user here
             return Ok(new { message = "Message sent successfully" });
         }
     }

--- a/backend/Controllers/MemoryController.cs
+++ b/backend/Controllers/MemoryController.cs
@@ -28,23 +28,22 @@ namespace SwAIvyn.Controllers
         }
 
         /// <summary>
-        /// Gets all memory items from both SQL database and Neo4j.
-        /// Since this is a single-user application, we don't filter by userId.
+        /// Gets all memory items for a specific user from both SQL database and Neo4j.
         /// </summary>
-        /// <param name="userId">User ID (ignored for single-user app)</param>
+        /// <param name="userId">User ID</param>
         /// <returns>List of memory items</returns>
         [HttpGet("{userId}")]
         public async Task<IActionResult> GetMemories(Guid userId)
         {
             try
             {
-                // Get ALL memories from SQL database (single-user app)
-                var sqlMemories = await _dbContext.Memories.ToListAsync();
+                // Get memories for the specified user from SQL database
+                var sqlMemories = await _dbContext.Memories
+                    .Where(m => m.UserId == userId)
+                    .ToListAsync();
 
-                // Get ALL memory IDs from Neo4j (single-user app)
-                // Use the default user ID for Neo4j operations
-                var defaultUserId = Guid.Parse("00000000-0000-0000-0000-000000000001");
-                var neo4jMemoryIds = await _brainGraphService.GetAllMemoryIdsAsync(defaultUserId);
+                // Get memory IDs for the specified user from Neo4j
+                var neo4jMemoryIds = await _brainGraphService.GetAllMemoryIdsAsync(userId);
 
                 // Find memories that exist in Neo4j but not in SQL
                 var sqlMemoryIds = sqlMemories.Select(m => m.Id).ToHashSet();
@@ -56,15 +55,19 @@ namespace SwAIvyn.Controllers
 
                 if (missingMemoryIds.Any())
                 {
-                    Console.WriteLine($"Found {missingMemoryIds.Count} memories in Neo4j that aren't in SQL database");
+                    Console.WriteLine($"Found {missingMemoryIds.Count} memories in Neo4j for user {userId} that aren't in SQL database");
 
                     // For each missing memory, try to get its content from Neo4j and create a SQL entry
                     foreach (var memoryId in missingMemoryIds)
                     {
                         try
                         {
-                            // Search for this specific memory in Neo4j to get its content
-                            var searchResults = await _brainGraphService.SearchAsync($"memory_id:{memoryId}", limit: 1);
+                            // Search for this specific memory in Neo4j to get its content, ensuring it's for the correct user
+                            // Assuming BrainGraphService.SearchAsync can filter by userId if the query includes it,
+                            // or that the memory_id is unique enough that userId check is implicitly handled by Neo4j permissions/structure.
+                            // For now, we rely on the fact that GetAllMemoryIdsAsync was already filtered by userId.
+                            // A more robust search would be: $"memory_id:{memoryId} AND user_id:{userId}" if supported by BrainGraphService
+                            var searchResults = await _brainGraphService.SearchAsync($"memory_id:{memoryId}", userId: userId, limit: 1);
 
                             if (searchResults.Any())
                             {
@@ -86,7 +89,7 @@ namespace SwAIvyn.Controllers
                                 var memoryItem = new MemoryItem
                                 {
                                     Id = memoryId,
-                                    UserId = defaultUserId, // Use default user ID for single-user app
+                                    UserId = userId, // Use the provided userId
                                     Content = content,
                                     Category = category,
                                     IsShared = isShared,
@@ -113,9 +116,10 @@ namespace SwAIvyn.Controllers
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error getting memories: {ex.Message}");
-                // Fallback to just SQL memories if there's an error (single-user app)
+                Console.WriteLine($"Error getting memories for user {userId}: {ex.Message}");
+                // Fallback to just SQL memories for the specific user if there's an error
                 var fallbackMemories = await _dbContext.Memories
+                    .Where(m => m.UserId == userId)
                     .OrderByDescending(m => m.CreatedAt)
                     .ToListAsync();
                 return Ok(fallbackMemories);
@@ -168,18 +172,20 @@ namespace SwAIvyn.Controllers
         }
 
         /// <summary>
-        /// Updates an existing memory item.
+        /// Updates an existing memory item for a specific user.
         /// </summary>
+        /// <param name="userId">User ID</param>
         /// <param name="id">Memory ID</param>
         /// <param name="request">Memory update request</param>
         /// <returns>Updated memory item</returns>
-        [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateMemory(Guid id, [FromBody] UpdateMemoryRequest request)
+        [HttpPut("{userId}/{id}")]
+        public async Task<IActionResult> UpdateMemory(Guid userId, Guid id, [FromBody] UpdateMemoryRequest request)
         {
-            var memory = await _dbContext.Memories.FindAsync(id);
+            var memory = await _dbContext.Memories.FirstOrDefaultAsync(m => m.Id == id && m.UserId == userId);
             if (memory == null)
             {
-                return NotFound();
+                // Could be NotFound or Forbid if the memory exists but belongs to another user
+                return NotFound($"Memory not found or not accessible by user {userId}");
             }
 
             memory.Content = request.Content;
@@ -193,17 +199,19 @@ namespace SwAIvyn.Controllers
         }
 
         /// <summary>
-        /// Deletes a memory item.
+        /// Deletes a memory item for a specific user.
         /// </summary>
+        /// <param name="userId">User ID</param>
         /// <param name="id">Memory ID</param>
         /// <returns>Action result</returns>
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteMemory(Guid id)
+        [HttpDelete("{userId}/{id}")]
+        public async Task<IActionResult> DeleteMemory(Guid userId, Guid id)
         {
-            var memory = await _dbContext.Memories.FindAsync(id);
+            var memory = await _dbContext.Memories.FirstOrDefaultAsync(m => m.Id == id && m.UserId == userId);
             if (memory == null)
             {
-                return NotFound();
+                // Could be NotFound or Forbid if the memory exists but belongs to another user
+                return NotFound($"Memory not found or not accessible by user {userId}");
             }
 
             // Remove from database

--- a/frontend/src/components/chat/VoiceSelector.tsx
+++ b/frontend/src/components/chat/VoiceSelector.tsx
@@ -1,72 +1,76 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Volume2 } from 'lucide-react';
-import ttsService from '../../services/ttsService';
+import ttsService from '../../services/ttsService'; // Keep for getVoices
 import { useInitialization } from '../../contexts/InitializationContext';
 
 interface VoiceSelectorProps {
-  onVoiceChange?: (voiceId: string) => void;
+  provider?: string | null;
+  voiceId?: string | null;
+  onSettingsChange?: (provider: string, voiceId: string) => void;
   disabled?: boolean;
 }
 
-const VoiceSelector: React.FC<VoiceSelectorProps> = ({ onVoiceChange, disabled = false }) => {
+const VoiceSelector: React.FC<VoiceSelectorProps> = ({
+  provider,
+  voiceId,
+  onSettingsChange,
+  disabled = false,
+}) => {
   const { user } = useInitialization();
-  const [selectedVoice, setSelectedVoice] = useState<string>('glados');
+  // availableVoices is still internal state, fetched based on provider prop
   const [availableVoices, setAvailableVoices] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loadingVoices, setLoadingVoices] = useState(false);
 
-  // Load available voices and current settings
-  useEffect(() => {
-    const loadVoicesAndSettings = async () => {
-      if (!user?.id) return;
-      
-      setLoading(true);
-      try {
-        // Load current TTS settings
-        const settings = await ttsService.getSettings(user.id);
-        const currentVoice = settings.voiceId || 'glados';
-        setSelectedVoice(currentVoice);
-        
-        // Load available voices based on current provider
-        const provider = settings.ttsProvider || 'fishspeech';
-        if (provider === 'fishspeech') {
-          // For Fish Speech, use hardcoded voices
-          const voices = ['jazzy', 'glados', 'scarlet'];
-          setAvailableVoices(voices);
-        } else {
-          // For ElevenLabs, use API or hardcoded list
-          const voices = ['Rachel', 'Domi', 'Bella', 'Antoni'];
-          setAvailableVoices(voices);
-        }
-      } catch (error) {
-        console.error('Failed to load voices and settings:', error);
-        // Fallback to hardcoded Fish Speech voices
-        setAvailableVoices(['jazzy', 'glados', 'scarlet']);
-      } finally {
-        setLoading(false);
+  const safeProvider = provider || 'fishspeech'; // Default to fishspeech if prop is null/undefined
+  const safeVoiceId = voiceId || 'glados';     // Default to glados if prop is null/undefined
+
+  // Load available voices when provider changes
+  const fetchVoicesForProvider = useCallback(async (currentProvider: string) => {
+    if (!user?.id || !currentProvider) {
+      setAvailableVoices(['glados']); // Default fallback
+      return;
+    }
+    
+    setLoadingVoices(true);
+    try {
+      console.log(`🔄 VoiceSelector: Fetching voices for provider: ${currentProvider}`);
+      // Assuming ttsService.getVoices can take a provider
+      // If not, this logic needs to adapt to how voices are fetched per provider
+      let voices: string[] = [];
+      if (currentProvider === 'fishspeech') {
+        voices = ['jazzy', 'glados', 'scarlet']; // Hardcoded for fishspeech as before
+      } else if (currentProvider === 'elevenlabs') {
+        voices = ['Rachel', 'Domi', 'Bella', 'Antoni']; // Hardcoded for elevenlabs
+      } else if (currentProvider === 'openai') {
+        voices = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer']; // Standard OpenAI voices
+      } else {
+        console.warn(`🔄 VoiceSelector: Unknown TTS provider "${currentProvider}", using default voices.`);
+        voices = ['glados']; // Fallback
       }
-    };
+      setAvailableVoices(voices);
+      console.log(`🔄 VoiceSelector: Voices for ${currentProvider}:`, voices);
 
-    loadVoicesAndSettings();
+      // If current voiceId from props isn't in the new list, maybe select the first one?
+      // Or let parent handle it via onSettingsChange if needed.
+      // For now, if safeVoiceId is not in 'voices', the dropdown might show blank or the first option.
+      // This can be improved if necessary by calling onSettingsChange with the first available voice.
+
+    } catch (error) {
+      console.error(`Failed to load voices for provider ${currentProvider}:`, error);
+      setAvailableVoices(['glados']); // Fallback
+    } finally {
+      setLoadingVoices(false);
+    }
   }, [user?.id]);
 
-  const handleVoiceChange = async (voiceId: string) => {
-    if (!user?.id) return;
-    
-    setSelectedVoice(voiceId);
-    
-    try {
-      // Update the voice setting in the database
-      await ttsService.updateSettings({
-        userId: user.id,
-        voiceId: voiceId
-      });
-      
-      // Notify parent component
-      if (onVoiceChange) {
-        onVoiceChange(voiceId);
-      }
-    } catch (error) {
-      console.error('Failed to update voice setting:', error);
+  useEffect(() => {
+    fetchVoicesForProvider(safeProvider);
+  }, [safeProvider, fetchVoicesForProvider]);
+
+
+  const handleInternalVoiceChange = (newVoiceId: string) => {
+    if (onSettingsChange) {
+      onSettingsChange(safeProvider, newVoiceId);
     }
   };
 
@@ -90,17 +94,17 @@ const VoiceSelector: React.FC<VoiceSelectorProps> = ({ onVoiceChange, disabled =
       <label htmlFor="voice-selector" className="sr-only">Select Voice</label>
       <select
         id="voice-selector"
-        value={selectedVoice}
-        onChange={(e) => handleVoiceChange(e.target.value)}
+        value={safeVoiceId} // Controlled by prop
+        onChange={(e) => handleInternalVoiceChange(e.target.value)}
         className="px-3 py-2 bg-white border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-w-[120px]"
-        disabled={disabled || loading}
+        disabled={disabled || loadingVoices}
       >
-        {loading ? (
+        {loadingVoices ? (
           <option value="">Loading voices...</option>
         ) : (
-          availableVoices.map(voice => (
-            <option key={voice} value={voice}>
-              {formatVoiceName(voice)}
+          availableVoices.map(v => (
+            <option key={v} value={v}>
+              {formatVoiceName(v)}
             </option>
           ))
         )}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -82,6 +82,8 @@ const ChatPage: React.FC = () => {
     useState<string | null>(null);
   const [chatModelOverride, setChatModelOverride] =
     useState<string | null>(null);
+  const [ttsProvider, setTtsProvider] = useState<string | null>(null);
+  const [ttsVoiceId, setTtsVoiceId] = useState<string | null>(null);
   const [availableLlms, setAvailableLlms] = useState<LlmOption[]>([]);
 
   /* ------------------------------ refs ----------------------------------- */
@@ -98,24 +100,30 @@ const ChatPage: React.FC = () => {
 
   /* ---------------------- SYNC FROM DASHBOARD LLM ------------------------ */
   useEffect(() => {
-    const syncFromDashboard = async () => {
+    const syncAllChatSettings = async () => {
       if (!user?.id) return;
 
       try {
-        const s = await chatService.getLlmSettings(user.id);
-        console.log('🔄 Chat: Syncing from Dashboard LLM:', s);
+        const settings = await chatService.getChatSettings(user.id);
+        console.log('🔄 Chat: Syncing all chat settings from backend:', settings);
 
-        // Always sync whatever is on dashboard
-        setChatEngineOverride(s?.engine || null);
-        setChatModelOverride(s?.model || null);
+        setChatEngineOverride(settings.llmEngine || null);
+        setChatModelOverride(settings.llmModel || null);
+        setTtsProvider(settings.ttsProvider || null);
+        setTtsVoiceId(settings.ttsVoiceId || null);
 
-        console.log('🔄 Chat: Chat now matches Dashboard →', s?.engine, s?.model);
+        console.log('🔄 Chat: Chat settings synced → LLM:', settings.llmEngine, settings.llmModel, 'TTS:', settings.ttsProvider, settings.ttsVoiceId);
       } catch (err) {
-        console.error('Dashboard sync failed:', err);
+        console.error('Chat settings sync failed:', err);
+        // Fallback or default settings if preferred
+        setChatEngineOverride(null); // Default LLM
+        setChatModelOverride(null);
+        setTtsProvider('fishspeech'); // Default TTS
+        setTtsVoiceId('glados');
       }
     };
 
-    syncFromDashboard();
+    syncAllChatSettings();
   }, [user?.id]); // Only run once when user loads
 
   /* ----------------------- auto-scroll on change ------------------------- */
@@ -678,7 +686,28 @@ const ChatPage: React.FC = () => {
               </label>
 
               {/* voice selector */}
-              <VoiceSelector disabled={isLoading} />
+              <VoiceSelector
+                disabled={isLoading}
+                provider={ttsProvider}
+                voiceId={ttsVoiceId}
+                onSettingsChange={async (newProvider, newVoiceId) => {
+                  if (!user?.id) return;
+                  console.log('🔄 Chat: VoiceSelector changed TTS to Provider:', newProvider, 'VoiceID:', newVoiceId);
+                  setTtsProvider(newProvider);
+                  setTtsVoiceId(newVoiceId);
+                  try {
+                    await chatService.updateChatSettings(user.id, {
+                      llmEngine: chatEngineOverride || '', // Pass current LLM engine or default
+                      llmModel: chatModelOverride || '',   // Pass current LLM model or default
+                      ttsProvider: newProvider,
+                      ttsVoiceId: newVoiceId,
+                    });
+                    console.log('🔄 Chat: TTS settings updated successfully via chatService.');
+                  } catch (error) {
+                    console.error('Failed to update TTS settings via chatService:', error);
+                  }
+                }}
+              />
 
               {/* LLM dropdown */}
               <select
@@ -692,39 +721,36 @@ const ChatPage: React.FC = () => {
                   const sel = availableLlms.find(
                     (l) => l.value === e.target.value
                   );
-                  if (!sel) {
-                    console.warn('🔄 Chat: Selected LLM option not found:', e.target.value);
+                  if (!sel || !user?.id) {
+                    console.warn('🔄 Chat: Selected LLM option not found or user ID missing:', e.target.value, user?.id);
                     return;
                   }
 
                   console.log('🔄 Chat: User changed LLM to:', sel);
+                  const newEngine = sel.engine;
+                  const newModel = sel.model;
 
-                  // Update local chat state
-                  setChatEngineOverride(sel.engine);
-                  setChatModelOverride(sel.model);
+                  setChatEngineOverride(newEngine);
+                  setChatModelOverride(newModel);
 
-                  // Update dashboard (database + sync event)
-                  if (user?.id && sel.engine) {
-                    try {
-                      console.log('🔄 Chat: Updating Dashboard LLM to:', sel.engine, sel.model);
+                  try {
+                    console.log('🔄 Chat: Updating all chat settings. New LLM:', newEngine, newModel, 'Current TTS:', ttsProvider, ttsVoiceId);
+                    await chatService.updateChatSettings(user.id, {
+                      llmEngine: newEngine || '', // Ensure empty string if null
+                      llmModel: newModel || '',   // Ensure empty string if null
+                      ttsProvider: ttsProvider || 'fishspeech', // Default if null
+                      ttsVoiceId: ttsVoiceId || 'glados',     // Default if null
+                    });
 
-                      await chatService.updateLlmSettings(
-                        sel.engine,
-                        sel.model || '',
-                        user.id
-                      );
-
-                      // Tell dashboard to update its display
-                      window.dispatchEvent(
-                        new CustomEvent('llmSettingsChanged', {
-                          detail: { engine: sel.engine, model: sel.model }
-                        })
-                      );
-
-                      console.log('🔄 Chat: Dashboard sync complete!');
-                    } catch (err) {
-                      console.error('Dashboard sync failed:', err);
-                    }
+                    // Notify dashboard about LLM part of the change
+                    window.dispatchEvent(
+                      new CustomEvent('llmSettingsChanged', {
+                        detail: { engine: newEngine, model: newModel }
+                      })
+                    );
+                    console.log('🔄 Chat: Chat settings (including LLM) updated and Dashboard notified.');
+                  } catch (err) {
+                    console.error('Failed to update chat settings:', err);
                   }
                 }}
                 className="px-3 py-2 border rounded-lg text-sm disabled:opacity-50"

--- a/frontend/src/services/chatService.ts
+++ b/frontend/src/services/chatService.ts
@@ -1,5 +1,20 @@
 import apiService from './apiService';
 
+// Matches backend DTOs
+export interface ChatSettings {
+  llmEngine: string;
+  llmModel: string;
+  ttsProvider: string;
+  ttsVoiceId: string;
+}
+
+export interface UpdateChatSettingsPayload {
+  llmEngine: string;
+  llmModel: string;
+  ttsProvider?: string; // Optional as per backend UpdateChatSettingsRequest
+  ttsVoiceId?: string;  // Optional as per backend UpdateChatSettingsRequest
+}
+
 /**
  * Service for chat-related API calls
  */
@@ -51,6 +66,47 @@ const chatService = {
   },
 
   /**
+   * Gets the consolidated chat settings for a user.
+   * @param userId The ID of the user.
+   * @returns The chat settings (LLM engine/model, TTS provider/voice).
+   */
+  async getChatSettings(userId: string): Promise<ChatSettings> {
+    try {
+      const url = `/api/chat/settings/${userId}`;
+      console.log('🔄 ChatService: Getting chat settings from:', url);
+      const response = await apiService.get(url);
+      console.log('🔄 ChatService: Chat settings API response:', response);
+      return response as ChatSettings;
+    } catch (error) {
+      console.error('Error getting chat settings:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Updates the consolidated chat settings for a user.
+   * @param userId The ID of the user.
+   * @param settings The settings payload.
+   * @returns True if successful, otherwise throws error.
+   */
+  async updateChatSettings(userId: string, settings: UpdateChatSettingsPayload): Promise<boolean> {
+    try {
+      const url = `/api/chat/settings/${userId}`;
+      console.log('🔄 ChatService: Updating chat settings at:', url, 'with payload:', settings);
+      // The backend returns { message: "Chat settings updated successfully." } which apiService should handle.
+      // We'll assume success if no error is thrown by apiService.post
+      await apiService.put(url, settings);
+      console.log('🔄 ChatService: Chat settings updated successfully.');
+      return true;
+    } catch (error) {
+      console.error('Error updating chat settings:', error);
+      throw error;
+    }
+  },
+
+  // Old methods - can be marked @deprecated or removed later if no longer used.
+  /**
+   * @deprecated Use getChatSettings instead.
    * Gets the current LLM settings
    * @param userId Optional user ID for user-specific settings
    * @returns The current LLM settings (engine and model)
@@ -71,6 +127,7 @@ const chatService = {
   },
 
   /**
+   * @deprecated Use updateChatSettings instead.
    * Updates the LLM settings
    * @param engine The LLM engine (ollama, lmstudio, openai or claude)
    * @param model The LLM model (for Ollama)

--- a/search/search.py
+++ b/search/search.py
@@ -214,13 +214,15 @@ class HybridSearchEngine:
                     source=metadata.get("source", "ingest")
                 )
 
-    async def recall_memory(self, query: str, top_k: int = 5) -> List[str]:
+    async def recall_memory(self, query: str, userId: Optional[str] = None, top_k: int = 5) -> List[str]:
         """
         Gate and return up to top_k relevant memory snippets,
         only if the top result clears memory_threshold.
+        Filters by userId if provided.
         """
         features = self.analyze_query(query)
-        graph_results = await self.neo4j_search(query, features, filters=None)
+        filters = {"userId": userId} if userId else None
+        graph_results = await self.neo4j_search(query, features, filters=filters)
         if not graph_results:
             return []
 
@@ -470,10 +472,16 @@ class HybridSearchEngine:
             self.logger.warning("Neo4j driver not available, returning mock data")
             return self._get_mock_neo4j_results(query, entities, 3)
 
+        user_id_filter = filters.get("userId") if filters else None
+
         try:
             import urllib.request, urllib.parse
             encoded_query = urllib.parse.quote(query)
             url = f"http://localhost:5000/api/brain/search?query={encoded_query}"
+            if user_id_filter:
+                url += f"&userId={urllib.parse.quote(str(user_id_filter))}"
+
+            self.logger.info(f"Calling backend Neo4j search: {url}")
             with urllib.request.urlopen(url) as response:
                 if response.status == 200:
                     backend_results = json.loads(response.read().decode())
@@ -502,11 +510,18 @@ class HybridSearchEngine:
                     self.logger.info(f"Neo4j vector search via backend API returned {len(results)} results")
                     return results
         except Exception as api_error:
-            self.logger.warning(f"Failed to call backend vector search API: {api_error}")
+            self.logger.warning(f"Failed to call backend vector search API: {api_error}. Falling back to Cypher.")
 
-        cypher = """
+        cypher_params = {"entity_list": entities}
+        cypher_where_clauses = ["ANY(entity IN $entity_list WHERE toLower(m.text) CONTAINS toLower(entity))"]
+
+        if user_id_filter:
+            cypher_where_clauses.append("m.userId = $userId")
+            cypher_params["userId"] = str(user_id_filter)
+
+        cypher = f"""
         MATCH (m:Memory)
-        WHERE ANY(entity IN $entity_list WHERE toLower(m.text) CONTAINS toLower(entity))
+        WHERE {" AND ".join(cypher_where_clauses)}
         RETURN m.id AS id,
                m.text AS content,
                m.category AS category,
@@ -516,8 +531,9 @@ class HybridSearchEngine:
         ORDER BY m.createdAt DESC
         LIMIT 50
         """
+        self.logger.info(f"Executing Cypher (entity_graph_search): {cypher} with params: {cypher_params}")
         async with self.neo4j.session() as session:
-            result = await session.run(cypher, entity_list=entities)
+            result = await session.run(cypher, **cypher_params)
             records = await result.data()
 
         results: List[SearchResult] = []
@@ -569,10 +585,16 @@ class HybridSearchEngine:
             self.logger.warning("Neo4j driver not available, returning mock data")
             return self._get_mock_neo4j_results(query, [], 2)
 
+        user_id_filter = filters.get("userId") if filters else None
+
         try:
             import urllib.request, urllib.parse
             encoded_query = urllib.parse.quote(query)
             url = f"http://localhost:5000/api/brain/search?query={encoded_query}"
+            if user_id_filter:
+                url += f"&userId={urllib.parse.quote(str(user_id_filter))}"
+
+            self.logger.info(f"Calling backend Neo4j search: {url}")
             with urllib.request.urlopen(url) as response:
                 if response.status == 200:
                     backend_results = json.loads(response.read().decode())
@@ -601,12 +623,18 @@ class HybridSearchEngine:
                     self.logger.info(f"Neo4j vector search via backend API returned {len(results)} results")
                     return results
         except Exception as api_error:
-            self.logger.warning(f"Failed to call backend vector search API: {api_error}")
+            self.logger.warning(f"Failed to call backend vector search API: {api_error}. Falling back to Cypher.")
 
-        fallback_cypher = """
+        cypher_params = {"query": query, "keywords": features.keywords or [query.lower()]}
+        cypher_where_clauses = ["(toLower(m.text) CONTAINS toLower($query) OR ANY(k IN $keywords WHERE toLower(m.text) CONTAINS toLower(k)))"]
+
+        if user_id_filter:
+            cypher_where_clauses.append("m.userId = $userId")
+            cypher_params["userId"] = str(user_id_filter)
+
+        fallback_cypher = f"""
         MATCH (m:Memory)
-        WHERE toLower(m.text) CONTAINS toLower($query)
-           OR ANY(k IN $keywords WHERE toLower(m.text) CONTAINS toLower(k))
+        WHERE {" AND ".join(cypher_where_clauses)}
         RETURN m.id AS id,
                m.text AS content,
                m.category AS category,
@@ -616,9 +644,9 @@ class HybridSearchEngine:
         ORDER BY m.createdAt DESC
         LIMIT 50
         """
-        keywords = features.keywords or [query.lower()]
+        self.logger.info(f"Executing Cypher (general_graph_search): {fallback_cypher} with params: {cypher_params}")
         async with self.neo4j.session() as session:
-            result = await session.run(fallback_cypher, query=query, keywords=keywords)
+            result = await session.run(fallback_cypher, **cypher_params)
             records = await result.data()
 
         results: List[SearchResult] = []


### PR DESCRIPTION
This commit addresses two main issues:
1. Memory Isolation:
    - Modified MemoryController.cs to filter memories by userId, ensuring you only access your own memories.
    - Updated search/search.py to pass userId to Neo4j and Weaviate searches, and to filter results accordingly in both API calls and fallback Cypher queries. This prevents memory leakage between different users or chats.

2. Chat Configuration Sync:
    - Enhanced ChatController.cs to manage your specific chat settings (LLM engine/model, TTS provider/voice) via new API endpoints (api/chat/settings/{userId}).
    - Integrated the frontend (ChatPage.tsx, VoiceSelector.tsx, chatService.ts) to use these new endpoints.
    - ChatPage now loads LLM and TTS settings from the backend on initialization.
    - Changes to LLM or voice settings on the ChatPage are persisted to the backend for you. This ensures that chat settings selected on the dashboard or within the chat page are consistently applied and maintained.