### PR TITLE
chore(gitignore): ignore weaviate_data and segment directories; add .dockerignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,14 @@ SwAIvyn.lnk
 
 # Keep essential configuration files (these are templates/source)
 # Note: Runtime configs are ignored above, but source configs are kept
+
+# Weaviate runtime data and vector index segments
+weaviate_data/
+weaviate/
+segments/
+**/segments/
+**/data/segments/
+
+# Docker ignore (mirrors .dockerignore)
+.dockerignore
+


### PR DESCRIPTION
Adds ignores for local runtime data so they don't show as pending changes:

- weaviate_data/
- weaviate/
- segments/, **/segments/, **/data/segments/
- also include .dockerignore entry for completeness

This keeps vector DB segments and local persistence out of version control.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author