### PR TITLE
Broadcast settings changes via SignalR

### DIFF
--- a/backend/Controllers/SettingsController.cs
+++ b/backend/Controllers/SettingsController.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using SwAIvyn.Hubs;
 using SwAIvyn.Services;
 
 namespace SwAIvyn.Controllers
@@ -16,6 +18,7 @@ namespace SwAIvyn.Controllers
         private readonly ISettingsService _settingsService;
         private readonly IAiChatService _aiChatService;
         private readonly ISimpleLoggerService _logger;
+        private readonly IHubContext<SettingsHub, ISettingsClient> _settingsHub;
 
         /// <summary>
         /// Initializes a new instance of the SettingsController
@@ -23,11 +26,13 @@ namespace SwAIvyn.Controllers
         public SettingsController(
             ISettingsService settingsService,
             IAiChatService aiChatService,
-            ISimpleLoggerService logger)
+            ISimpleLoggerService logger,
+            IHubContext<SettingsHub, ISettingsClient> settingsHub)
         {
             _settingsService = settingsService;
             _aiChatService = aiChatService;
             _logger = logger;
+            _settingsHub = settingsHub;
         }
 
         /// <summary>
@@ -81,6 +86,14 @@ namespace SwAIvyn.Controllers
                 var success = await _settingsService.SetSettingAsync(request.UserId, key, request.Value);
                 if (success)
                 {
+                    if (request.UserId.HasValue)
+                    {
+                        await _settingsHub.Clients.User(request.UserId.Value.ToString()).SettingsChanged();
+                    }
+                    else
+                    {
+                        await _settingsHub.Clients.All.SettingsChanged();
+                    }
                     return Ok(new { message = $"Setting '{key}' updated successfully" });
                 }
                 return StatusCode(500, $"Failed to update setting '{key}'");
@@ -103,6 +116,14 @@ namespace SwAIvyn.Controllers
                 var success = await _settingsService.SetSettingsAsync(request.UserId, request.Settings);
                 if (success)
                 {
+                    if (request.UserId.HasValue)
+                    {
+                        await _settingsHub.Clients.User(request.UserId.Value.ToString()).SettingsChanged();
+                    }
+                    else
+                    {
+                        await _settingsHub.Clients.All.SettingsChanged();
+                    }
                     return Ok(new { message = "Settings updated successfully" });
                 }
                 return StatusCode(500, "Failed to update settings");
@@ -188,6 +209,14 @@ namespace SwAIvyn.Controllers
                 var success = await _settingsService.SetSettingsAsync(request.UserId, settings);
                 if (success)
                 {
+                    if (request.UserId.HasValue)
+                    {
+                        await _settingsHub.Clients.User(request.UserId.Value.ToString()).SettingsChanged();
+                    }
+                    else
+                    {
+                        await _settingsHub.Clients.All.SettingsChanged();
+                    }
                     return Ok(new { message = "Connection settings updated successfully" });
                 }
                 return StatusCode(500, "Failed to update connection settings");
@@ -229,7 +258,17 @@ namespace SwAIvyn.Controllers
                     request.UserId, request.Engine, request.Model);
 
                 if (success)
+                {
+                    if (request.UserId.HasValue)
+                    {
+                        await _settingsHub.Clients.User(request.UserId.Value.ToString()).SettingsChanged();
+                    }
+                    else
+                    {
+                        await _settingsHub.Clients.All.SettingsChanged();
+                    }
                     return Ok(new { message = "LLM settings updated successfully" });
+                }
 
                 return StatusCode(500, "Failed to update LLM settings");
             }

--- a/backend/Hubs/SettingsHub.cs
+++ b/backend/Hubs/SettingsHub.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using System.Threading.Tasks;
+
+namespace SwAIvyn.Hubs
+{
+    /// <summary>
+    /// Hub used to notify clients when settings change so they can refresh cached values.
+    /// </summary>
+    public interface ISettingsClient
+    {
+        /// <summary>
+        /// Triggered when any user setting is updated.
+        /// </summary>
+        /// <returns>A task that completes when the notification has been sent.</returns>
+        Task SettingsChanged();
+    }
+
+    /// <summary>
+    /// SignalR hub for broadcasting settings updates.
+    /// </summary>
+    [Authorize]
+    public class SettingsHub : Hub<ISettingsClient>
+    {
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -833,6 +833,7 @@ app.MapGet("/readyz", () =>
 app.MapHub<ChatHub>("/hubs/chat").RequireCors("CorsPolicy");
 app.MapHub<VoiceHub>("/hubs/voice").RequireCors("CorsPolicy");
 app.MapHub<NotificationHub>("/hubs/notification").RequireCors("CorsPolicy");
+app.MapHub<SettingsHub>("/hubs/settings").RequireCors("CorsPolicy");
 
 app.MapGet("/api/health/neo4j", async (INeo4jService nx) =>
     Results.Ok(await nx.GetStatusAsync())


### PR DESCRIPTION
## Summary
- add `SettingsHub` with `SettingsChanged` event to broadcast updates
- notify clients after settings, connection, or LLM changes
- expose the hub at `/hubs/settings`
- secure the hub and scope notifications to individual users

## Testing
- `dotnet build backend/SwAIvyn.csproj`
- `dotnet test backend/SwAIvyn.csproj` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cf7134848329922bec16321e5401