### PR TITLE
Fix Temporal service database discovery in stack

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -189,6 +189,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PWD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=temporal
+      - POSTGRES_SEEDS=swai-db
     networks:
       - swai-public
     ports:
@@ -239,7 +240,9 @@ services:
     volumes:
       - swai_data:/var/lib/postgresql/data
     networks:
-      - swai-public
+      swai-public:
+        aliases:
+          - swai-db
     ports:
       - target: 5432
         published: 5432


### PR DESCRIPTION
## Summary
- ensure the Temporal Swarm service can locate the PostgreSQL database by exporting POSTGRES_SEEDS
- expose the swai-db service on the overlay network with a stable swai-db alias

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cadc4eb03883298ee493a463f5f962