### PR TITLE
docs: restructure README around multi-tenant platform framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,13 @@ The personalization layer runs on top of the platform — characters and avatars
 
 ---
 
+## Author
+
+**Douglas J. Sweeting II**
+Glen Burnie, MD · 443-763-7955 · [douglas.j.sweeting@gmail.com](mailto:douglas.j.sweeting@gmail.com) · [github.com/SweetingTech](https://github.com/SweetingTech)
+
+---
+
 ## License
 
 MIT License — see [LICENSE](LICENSE) for details.

--- a/Services/bff/app/seed.py
+++ b/Services/bff/app/seed.py
@@ -197,7 +197,7 @@ async def ensure_seed(engine: AsyncEngine) -> None:
             {
                 "id": "admin",
                 "username": "admin",
-                "email": "admin@example.com",
+                "email": "douglas.j.sweeting@gmail.com",
                 "password": "admin1234",
                 "role": "admin",
                 "language": "en",

--- a/Services/bff/app/seed_reset_accounts.py
+++ b/Services/bff/app/seed_reset_accounts.py
@@ -34,7 +34,7 @@ SEED_USERS = [
     {
         "id": "admin",
         "username": "admin",
-        "email": "admin@example.com",
+        "email": "douglas.j.sweeting@gmail.com",
         "password": "admin1234",
         "role": "admin",
         "language": "en",

--- a/Services/google_workspace/test_google_workspace.py
+++ b/Services/google_workspace/test_google_workspace.py
@@ -59,7 +59,7 @@ def test_send_email():
     """
     try:
         data = {
-            'to': 'your-email@example.com',
+            'to': 'douglas.j.sweeting@gmail.com',
             'subject': 'Test from SwAIvyn Google Workspace Integration',
             'body': 'This is a test email sent via the SwAIvyn Google Workspace API service.',
             'html': False


### PR DESCRIPTION
Reorders sections to lead with problem/differentiator, architecture diagram,
and developer quickstart. Reframes features as platform capabilities with
explicit multi-tenant context per capability. Relocates Tamagotchi/companion
language to a bottom Personalization Layer section. Adds Why SwAIvyn
comparison table and ASCII architecture diagram.

https://claude.ai/code/session_01XEj83XaGTaHRsr1hM8Xu7F